### PR TITLE
fix return type for glGetString

### DIFF
--- a/vapi/gl.vapi
+++ b/vapi/gl.vapi
@@ -11161,9 +11161,9 @@ namespace GL {
 	[CCode (cheader_filename = "GL/glew.h", cname = "glGetSharpenTexFuncSGIS")]
 	public static void glGetSharpenTexFuncSGIS (GL.GLenum target, [CCode (array_length = false)] GL.GLfloat[] points);
 	[CCode (cheader_filename = "GL/glew.h", cname = "glGetString")]
-	public static GL.GLubyte glGetString (GL.GLenum name);
+	public static unowned string? glGetString (GL.GLenum name);
 	[CCode (cheader_filename = "GL/glew.h", cname = "glGetStringi")]
-	public static GL.GLubyte glGetStringi (GL.GLenum name, GL.GLuint index);
+	public static unowned string? glGetStringi (GL.GLenum name, GL.GLuint index);
 	[CCode (cheader_filename = "GL/glew.h", cname = "glGetSubroutineIndex")]
 	public static GL.GLuint glGetSubroutineIndex (GL.GLuint program, GL.GLenum shadertype, string name);
 	[CCode (cheader_filename = "GL/glew.h", cname = "glGetSubroutineUniformLocation")]


### PR DESCRIPTION
glGetString and glGetStringi may return NULL
and this functions return const char* as unowned refs
it crashes in original