### PR TITLE
Added some Glew specific functions for debugging

### DIFF
--- a/vapi/glew-minimal.vapi
+++ b/vapi/glew-minimal.vapi
@@ -8,10 +8,10 @@
     to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
     copies of the Software, and to permit persons to whom the Software is
     furnished to do so, subject to the following conditions:
-    
+
     The above copyright notice and this permission notice shall be included in
     all copies or substantial portions of the Software.
-    
+
     THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
     IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
     FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
@@ -24,4 +24,12 @@
 namespace GLEW {
 	[CCode (cheader_filename = "GL/glew.h", cname = "glewInit")]
 	public static uint glewInit ();
+	[CCode (cheader_filename = "GL/glew.h", cname = "GLEW_OK")]
+	public const uint GLEW_OK;
+	[CCode (cheader_filename = "GL/glew.h", cname = "glewGetErrorString")]
+	public static unowned string? glewGetErrorString (uint error);
+	[CCode (cheader_filename = "GL/glew.h", cname = "glewGetString")]
+	public static unowned string? glewGetString (uint name);
+	[CCode (cheader_filename = "GL/glew.h", cname = "GLEW_VERSION")]
+	public const uint GLEW_VERSION;
 }


### PR DESCRIPTION
I forgot to call `glewInit()`. So this PR is a follow up and fixes #4. The things added to the Glew VAPI enables a bit more robust code when initializing GLEW. Although its not strictly necessary, so feel free to close this PR without merging:

```
var glew_error = GLEW.glewInit ();
if (glew_error != GLEW.GLEW_OK) {
    critical ("Error initializing GLEW: %s", GLEW.glewGetErrorString (glew_error));
}
debug ("Using GLEW %s", GLEW.glewGetString (GLEW.GLEW_VERSION));
```